### PR TITLE
Added support for mysql information schema

### DIFF
--- a/mysql/infoschema.go
+++ b/mysql/infoschema.go
@@ -1,0 +1,357 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/schema"
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+)
+
+// ProcessInfoSchema performs schema conversion for source database
+// 'db'. We assume that the source database supports information
+// schema tables. These tables are a broadly supported ANSI standard,
+// and we use them to obtain source database's schema information.
+func ProcessInfoSchema(conv *internal.Conv, db *sql.DB) error {
+	tables, err := getTables(db)
+	if err != nil {
+		return err
+	}
+	for _, t := range tables {
+		if err := processTable(conv, db, t); err != nil {
+			return err
+		}
+	}
+	schemaToDDL(conv)
+	conv.AddPrimaryKeys()
+	return nil
+}
+
+// ProcessSqlData performs data conversion for source database
+// 'db'. For each table, we extract data using a "SELECT (colNamesList)" query,
+// convert the data to Spanner data (based on the source and Spanner
+// schemas), and write it to Spanner.  If we can't get/process data
+// for a table, we skip that table and process the remaining tables.
+//
+// Note that the database/sql library has a somewhat complex model for
+// returning data from rows.Scan. We pass *sql.RawBytes to rows.scan.
+// RawBytes is a byte slice and values can be easily converted to string.
+
+func ProcessSqlData(conv *internal.Conv, db *sql.DB) {
+	tables, err := getTables(db)
+	if err != nil {
+		conv.Unexpected(fmt.Sprintf("Couldn't get list of table: %s", err))
+		return
+	}
+	for _, t := range tables {
+		srcTable := buildTableName(t.schema, t.name)
+		srcSchema, ok1 := conv.SrcSchema[srcTable]
+		if !ok1 {
+			conv.Stats.BadRows[srcTable] += conv.Stats.Rows[srcTable]
+			conv.Unexpected(fmt.Sprintf("Can't get schemas for table %s", srcTable))
+			continue
+		}
+		srcCols := srcSchema.ColNames
+		if len(srcCols) == 0 {
+			conv.Unexpected(fmt.Sprintf("Couldn't get source columns for table %s ", t.name))
+			continue
+		}
+		colNameList := buildColNameList(srcSchema, srcCols)
+		// MYSQL schema and name can be arbitrary strings. Ideally we would pass schema/name
+		// as a query parameter,but MYSQL doesn't support this. So we quote it instead.
+		q := fmt.Sprintf(`SELECT %s FROM %s.%s;`, colNameList, t.schema, t.name)
+		rows, err := db.Query(q)
+		if err != nil {
+			conv.Unexpected(fmt.Sprintf("Couldn't get data for table %s : err = %s", t.name, err))
+			continue
+		}
+		defer rows.Close()
+		spTable, err := internal.GetSpannerTable(conv, srcTable)
+		if err != nil {
+			conv.Unexpected(fmt.Sprintf("Couldn't get spanner table : %s", err))
+			continue
+		}
+		spCols, err := internal.GetSpannerCols(conv, srcTable, srcCols)
+		if err != nil {
+			conv.Unexpected(fmt.Sprintf("Couldn't get spanner columns for table %s : err = %s", t.name, err))
+			continue
+		}
+		spSchema, ok2 := conv.SpSchema[spTable]
+		if !ok2 {
+			conv.Stats.BadRows[srcTable] += conv.Stats.Rows[srcTable]
+			conv.Unexpected(fmt.Sprintf("Can't get schemas for table %s", srcTable))
+			continue
+		}
+		// Make a slice for the values
+		v := make([]sql.RawBytes, len(srcCols))
+		scanArgs := make([]interface{}, len(v))
+		for i := range v {
+			scanArgs[i] = &v[i]
+		}
+		// Fetch rows
+		for rows.Next() {
+			// get RawBytes from data
+			err = rows.Scan(scanArgs...)
+			if err != nil {
+				conv.Unexpected(fmt.Sprintf("Couldn't process sql data row: %s", err))
+				conv.StatsAddBadRow(srcTable, conv.DataMode())
+				continue
+			}
+			values := valsToStrings(v)
+			ProcessDataRow(conv, srcTable, srcCols, srcSchema, spTable, spCols, spSchema, values)
+		}
+	}
+}
+
+// Building list of column names to support spatial datatypes instead of
+// using 'SELECT *'. So spatial columns will be fetched using ST_AsText().
+func buildColNameList(srcSchema schema.Table, srcColName []string) string {
+	var srcColTypes []string
+	var colList, colTmpName string
+	for _, colName := range srcColName {
+		// To handle cases where column name is reserved keyword or having space between words
+		colTmpName = "`" + colName + "`"
+		srcColTypes = append(srcColTypes, srcSchema.ColDefs[colName].Type.Name)
+		for _, spatial := range MysqlSpatialDataTypes {
+			if strings.Contains(strings.ToLower(srcSchema.ColDefs[colName].Type.Name), spatial) {
+				colTmpName = "ST_AsText" + "(" + colTmpName + ")" + colTmpName
+				break
+			}
+		}
+		colList = colList + colTmpName + ","
+	}
+	return colList[:len(colList)-1]
+}
+
+// SetRowStats populates conv with the number of rows in each table.
+func SetRowStats(conv *internal.Conv, db *sql.DB) {
+	tables, err := getTables(db)
+	if err != nil {
+
+		conv.Unexpected(fmt.Sprintf("Couldn't get list of table: %s", err))
+		return
+	}
+	for _, t := range tables {
+		// MYSQL schema and name can be arbitrary strings.
+		// Ideally we would pass schema/name as a query parameter,
+		// but MYSQL doesn't support this. So we quote it instead.
+		q := fmt.Sprintf(`SELECT COUNT(*) FROM %s.%s;`, t.schema, t.name)
+		tableName := buildTableName(t.schema, t.name)
+		rows, err := db.Query(q)
+		if err != nil {
+			conv.Unexpected(fmt.Sprintf("Couldn't get number of rows for table %s", tableName))
+			continue
+		}
+		defer rows.Close()
+		var count int64
+		if rows.Next() {
+			err := rows.Scan(&count)
+			if err != nil {
+				fmt.Printf("Can't get row count: %s\n", err)
+				continue
+			}
+			conv.Stats.Rows[tableName] += count
+		}
+	}
+}
+
+type schemaAndName struct {
+	schema string
+	name   string
+}
+
+func getTables(db *sql.DB) ([]schemaAndName, error) {
+	ignored := make(map[string]bool)
+	// Ignore all system tables: we just want to convert user tables.
+	for _, s := range []string{"information_schema", "mysql", "performance_schema", "sys"} {
+		ignored[s] = true
+	}
+	q := "SELECT table_schema, table_name FROM information_schema.tables where table_type = 'BASE TABLE'"
+	rows, err := db.Query(q)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get tables: %w\n", err)
+	}
+	defer rows.Close()
+	var tableSchema, tableName string
+	var tables []schemaAndName
+	for rows.Next() {
+		rows.Scan(&tableSchema, &tableName)
+		if !ignored[tableSchema] {
+			tables = append(tables, schemaAndName{schema: tableSchema, name: tableName})
+		}
+	}
+	return tables, nil
+}
+
+func processTable(conv *internal.Conv, db *sql.DB, table schemaAndName) error {
+	cols, err := getColumns(table, db)
+	if err != nil {
+		return fmt.Errorf("couldn't get schema for table %s.%s: %s\n", table.schema, table.name, err)
+	}
+	defer cols.Close()
+	primaryKeys, constraints, err := getConstraints(conv, db, table)
+	if err != nil {
+		return fmt.Errorf("couldn't get constraints for table %s.%s: %s\n", table.schema, table.name, err)
+	}
+	colDefs, colNames := processColumns(conv, cols, constraints)
+	name := buildTableName(table.schema, table.name)
+	var schemaPKeys []schema.Key
+	for _, k := range primaryKeys {
+		schemaPKeys = append(schemaPKeys, schema.Key{Column: k})
+	}
+	conv.SrcSchema[name] = schema.Table{
+		Name:        name,
+		ColNames:    colNames,
+		ColDefs:     colDefs,
+		PrimaryKeys: schemaPKeys}
+	return nil
+}
+
+func getColumns(table schemaAndName, db *sql.DB) (*sql.Rows, error) {
+	q := `SELECT c.column_name, c.data_type, c.column_type, c.is_nullable, c.column_default, c.character_maximum_length, c.numeric_precision, c.numeric_scale
+              FROM information_schema.COLUMNS c
+              where table_schema = ? and table_name = ? ORDER BY c.ordinal_position;`
+	return db.Query(q, table.schema, table.name)
+}
+
+func processColumns(conv *internal.Conv, cols *sql.Rows, constraints map[string][]string) (map[string]schema.Column, []string) {
+	colDefs := make(map[string]schema.Column)
+	var colNames []string
+	var colName, dataType, isNullable, columnType string
+	var colDefault sql.NullString
+	var charMaxLen, numericPrecision, numericScale sql.NullInt64
+	for cols.Next() {
+		err := cols.Scan(&colName, &dataType, &columnType, &isNullable, &colDefault, &charMaxLen, &numericPrecision, &numericScale)
+		if err != nil {
+			fmt.Printf("Can't scan: %v\n", err)
+			continue
+		}
+		unique := false
+		ignored := schema.Ignored{}
+		for _, c := range constraints[colName] {
+			// c can be UNIQUE, PRIMARY KEY, FOREIGN KEY or CHECK
+			// We've already filtered out PRIMARY KEY.
+			switch c {
+			case "UNIQUE":
+				unique = true
+			case "FOREIGN KEY":
+				ignored.ForeignKey = true
+			case "CHECK":
+				ignored.Check = true
+			}
+		}
+		ignored.Default = colDefault.Valid
+		c := schema.Column{
+			Name:    colName,
+			Type:    toType(dataType, columnType, charMaxLen, numericPrecision, numericScale),
+			NotNull: toNotNull(conv, isNullable),
+			Unique:  unique,
+			Ignored: ignored,
+		}
+		colDefs[colName] = c
+		colNames = append(colNames, colName)
+	}
+	return colDefs, colNames
+}
+
+// getConstraints returns a list of primary keys and by-column map of
+// other constraints.  Note: we need to preserve ordinal order of
+// columns in primary key constraints.
+func getConstraints(conv *internal.Conv, db *sql.DB, table schemaAndName) ([]string, map[string][]string, error) {
+	q := `SELECT k.COLUMN_NAME, t.CONSTRAINT_TYPE
+              FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS t
+                INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS k
+                  ON t.CONSTRAINT_NAME = k.CONSTRAINT_NAME AND t.CONSTRAINT_SCHEMA = k.CONSTRAINT_SCHEMA AND t.TABLE_NAME=k.TABLE_NAME
+              WHERE k.TABLE_SCHEMA = ? AND k.TABLE_NAME = ? ORDER BY k.ordinal_position;`
+	rows, err := db.Query(q, table.schema, table.name)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+	var primaryKeys []string
+	var col, constraint string
+	m := make(map[string][]string)
+	for rows.Next() {
+		err := rows.Scan(&col, &constraint)
+		if err != nil {
+			fmt.Printf("Can't scan: %v\n", err)
+			continue
+		}
+		if col == "" || constraint == "" {
+			fmt.Printf("Got empty col or constraint\n")
+			continue
+		}
+		switch constraint {
+		case "PRIMARY KEY":
+			primaryKeys = append(primaryKeys, col)
+		default:
+			m[col] = append(m[col], constraint)
+		}
+	}
+	return primaryKeys, m, nil
+}
+
+func toType(dataType string, columnType string, charLen sql.NullInt64, numericPrecision, numericScale sql.NullInt64) schema.Type {
+	switch {
+	case dataType == "set":
+		return schema.Type{Name: dataType, ArrayBounds: []int64{-1}}
+	case charLen.Valid && dataType != "enum":
+		return schema.Type{Name: dataType, Mods: []int64{charLen.Int64}}
+	case dataType == "decimal" && numericPrecision.Valid && numericScale.Valid && numericScale.Int64 != 0:
+		return schema.Type{Name: dataType, Mods: []int64{numericPrecision.Int64, numericScale.Int64}}
+	case dataType == "decimal" && numericPrecision.Valid:
+		return schema.Type{Name: dataType, Mods: []int64{numericPrecision.Int64}}
+	default:
+		return schema.Type{Name: dataType}
+	}
+}
+
+func toNotNull(conv *internal.Conv, isNullable string) bool {
+	switch isNullable {
+	case "YES":
+		return false
+	case "NO":
+		return true
+	}
+	conv.Unexpected(fmt.Sprintf("isNullable column has unknown value: %s", isNullable))
+	return false
+}
+
+func valsToStrings(vals []sql.RawBytes) []string {
+	toString := func(val sql.RawBytes) string {
+		if val == nil {
+			return "NULL"
+		} else {
+			return string(val)
+		}
+	}
+	var s []string
+	for _, v := range vals {
+		s = append(s, toString(v))
+	}
+	return s
+}
+
+func buildTableName(schema, name string) string {
+	if schema == "public" { // Drop 'public' prefix.
+		return name
+	}
+	return fmt.Sprintf("%s.%s", schema, name)
+}

--- a/mysql/infoschema_test.go
+++ b/mysql/infoschema_test.go
@@ -1,0 +1,306 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cloudspannerecosystem/harbourbridge/internal"
+	"github.com/cloudspannerecosystem/harbourbridge/schema"
+	"github.com/cloudspannerecosystem/harbourbridge/spanner/ddl"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockSpec struct {
+	query string
+	args  []driver.Value   // Query args.
+	cols  []string         // Columns names for returned rows.
+	rows  [][]driver.Value // Set of rows returned.
+}
+
+func TestProcessInfoSchemaMYSQL(t *testing.T) {
+	ms := []mockSpec{
+		{
+			query: "SELECT table_schema, table_name FROM information_schema.tables where table_type = 'BASE TABLE'",
+			cols:  []string{"table_schema", "table_name"},
+			rows: [][]driver.Value{
+				{"public", "cart"},
+				{"public", "test"}},
+		}, {
+			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
+			args:  []driver.Value{"public", "cart"},
+			cols:  []string{"column_name", "data_type", "column_type", "is_nullable", "column_default", "character_maximum_length", "numeric_precision", "numeric_scale"},
+			rows: [][]driver.Value{
+				{"productid", "text", "text", "NO", nil, nil, nil, nil},
+				{"userid", "text", "text", "NO", nil, nil, nil, nil},
+				{"quantity", "bigint", "bigint", "YES", nil, nil, 64, 0}},
+		}, {
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
+			args:  []driver.Value{"public", "cart"},
+			cols:  []string{"column_name", "constraint_type"},
+			rows: [][]driver.Value{
+				{"productid", "PRIMARY KEY"},
+				{"userid", "PRIMARY KEY"}},
+		}, {
+			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
+			args:  []driver.Value{"public", "test"},
+			cols:  []string{"column_name", "data_type", "column_type", "is_nullable", "column_default", "character_maximum_length", "numeric_precision", "numeric_scale"},
+			rows: [][]driver.Value{
+				{"id", "bigint", "bigint", "NO", nil, nil, 64, 0},
+				{"s", "set", "set", "YES", nil, nil, nil, nil},
+				{"txt", "text", "text", "NO", nil, nil, nil, nil},
+				{"b", "boolean", "boolean", "YES", nil, nil, nil, nil},
+				{"bs", "bigint", "bigint", "NO", "nextval('test11_bs_seq'::regclass)", nil, 64, 0},
+				{"bl", "blob", "blob", "YES", nil, nil, nil, nil},
+				{"c", "char", "char(1)", "YES", nil, 1, nil, nil},
+				{"c8", "char", "char(8)", "YES", nil, 8, nil, nil},
+				{"d", "date", "date", "YES", nil, nil, nil, nil},
+				{"f8", "double", "double", "YES", nil, nil, 53, nil},
+				{"f4", "float", "float", "YES", nil, nil, 24, nil},
+				{"i8", "bigint", "bigint", "YES", nil, nil, 64, 0},
+				{"i4", "integer", "integer", "YES", nil, nil, 32, 0},
+				{"i2", "smallint", "smallint", "YES", nil, nil, 16, 0},
+				{"si", "integer", "integer", "NO", "nextval('test11_s_seq'::regclass)", nil, 32, 0},
+				{"ts", "datetime", "datetime", "YES", nil, nil, nil, nil},
+				{"tz", "timestamp", "timestamp", "YES", nil, nil, nil, nil},
+				{"vc", "varchar", "varchar", "YES", nil, nil, nil, nil},
+				{"vc6", "varchar", "varchar(6)", "YES", nil, 6, nil, nil}},
+		},
+		{
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
+			args:  []driver.Value{"public", "test"},
+			cols:  []string{"column_name", "constraint_type"},
+			rows:  [][]driver.Value{{"id", "PRIMARY KEY"}},
+		},
+	}
+	db := mkMockDb(t, ms)
+	conv := internal.MakeConv()
+	err := ProcessInfoSchema(conv, db)
+	assert.Nil(t, err)
+	expectedSchema := map[string]ddl.CreateTable{
+		"cart": ddl.CreateTable{
+			Name:     "cart",
+			ColNames: []string{"productid", "userid", "quantity"},
+			ColDefs: map[string]ddl.ColumnDef{
+				"productid": ddl.ColumnDef{Name: "productid", T: ddl.String{Len: ddl.MaxLength{}}, NotNull: true},
+				"userid":    ddl.ColumnDef{Name: "userid", T: ddl.String{Len: ddl.MaxLength{}}, NotNull: true},
+				"quantity":  ddl.ColumnDef{Name: "quantity", T: ddl.Int64{}},
+			},
+			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "productid"}, ddl.IndexKey{Col: "userid"}}},
+		"test": ddl.CreateTable{
+			Name:     "test",
+			ColNames: []string{"id", "s", "txt", "b", "bs", "bl", "c", "c8", "d", "f8", "f4", "i8", "i4", "i2", "si", "ts", "tz", "vc", "vc6"},
+			ColDefs: map[string]ddl.ColumnDef{
+				"id":  ddl.ColumnDef{Name: "id", T: ddl.Int64{}, NotNull: true},
+				"s":   ddl.ColumnDef{Name: "s", T: ddl.String{Len: ddl.MaxLength{}}, IsArray: true},
+				"txt": ddl.ColumnDef{Name: "txt", T: ddl.String{Len: ddl.MaxLength{}}, NotNull: true},
+				"b":   ddl.ColumnDef{Name: "b", T: ddl.Bool{}},
+				"bs":  ddl.ColumnDef{Name: "bs", T: ddl.Int64{}, NotNull: true},
+				"bl":  ddl.ColumnDef{Name: "bl", T: ddl.Bytes{Len: ddl.MaxLength{}}},
+				"c":   ddl.ColumnDef{Name: "c", T: ddl.String{Len: ddl.Int64Length{Value: 1}}},
+				"c8":  ddl.ColumnDef{Name: "c8", T: ddl.String{Len: ddl.Int64Length{Value: 8}}},
+				"d":   ddl.ColumnDef{Name: "d", T: ddl.Date{}},
+				"f8":  ddl.ColumnDef{Name: "f8", T: ddl.Float64{}},
+				"f4":  ddl.ColumnDef{Name: "f4", T: ddl.Float64{}},
+				"i8":  ddl.ColumnDef{Name: "i8", T: ddl.Int64{}},
+				"i4":  ddl.ColumnDef{Name: "i4", T: ddl.Int64{}},
+				"i2":  ddl.ColumnDef{Name: "i2", T: ddl.Int64{}},
+				"si":  ddl.ColumnDef{Name: "si", T: ddl.Int64{}, NotNull: true},
+				"ts":  ddl.ColumnDef{Name: "ts", T: ddl.Timestamp{}},
+				"tz":  ddl.ColumnDef{Name: "tz", T: ddl.Timestamp{}},
+				"vc":  ddl.ColumnDef{Name: "vc", T: ddl.String{Len: ddl.MaxLength{}}},
+				"vc6": ddl.ColumnDef{Name: "vc6", T: ddl.String{Len: ddl.Int64Length{Value: 6}}},
+			},
+			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "id"}}},
+	}
+	assert.Equal(t, expectedSchema, stripSchemaComments(conv.SpSchema))
+	assert.Equal(t, len(conv.Issues["cart"]), 0)
+	expectedIssues := map[string][]internal.SchemaIssue{
+		"bs": []internal.SchemaIssue{internal.DefaultValue},
+		"f4": []internal.SchemaIssue{internal.Widened},
+		"i4": []internal.SchemaIssue{internal.Widened},
+		"i2": []internal.SchemaIssue{internal.Widened},
+		"si": []internal.SchemaIssue{internal.Widened, internal.DefaultValue},
+		"ts": []internal.SchemaIssue{internal.Datetime},
+	}
+	assert.Equal(t, expectedIssues, conv.Issues["test"])
+	assert.Equal(t, int64(0), conv.Unexpecteds())
+}
+
+// TODO : Remove this test
+// This test is not required as this case is covered in data_test
+// Because we have merged data_conversion functionality for Info_schema
+// and dump in mysql. Thus,we are calling ProcessDataRow() directly from Infoschema
+// which calls ConvertData() for data conversion.
+func TestConvertSqlRow_SingleCol(t *testing.T) {
+	//tDate, _ := time.Parse("2006-01-02", "2019-10-29")
+	tc := []struct {
+		name    string
+		ty      ddl.ScalarType
+		isArray bool
+		srcTy   string      // Source DB type (Used by e.g. timestamp conversions).
+		in      string      // Input value for conversion.
+		e       interface{} // Expected result.
+	}{
+		{"bool", ddl.Bool{}, false, "", "1", true},
+		{"bytes", ddl.Bytes{Len: ddl.MaxLength{}}, false, "", string([]byte{137, 80}), []byte{0x89, 0x50}}, // need some other approach to testblob type
+		{"date", ddl.Date{}, false, "", "2019-10-29", getDate("2019-10-29")},
+		{"float64", ddl.Float64{}, false, "", "42.6", float64(42.6)},
+		{"int64", ddl.Int64{}, false, "", "42", int64(42)},
+		{"string", ddl.String{Len: ddl.MaxLength{}}, false, "", "eh", "eh"},
+		{"datetime", ddl.Timestamp{}, false, "datetime", "2019-10-29 05:30:00", getTimeWithoutTimezone(t, "2019-10-29 05:30:00")},
+		{"timestamp", ddl.Timestamp{}, false, "timestamp", "2019-10-29 05:30:00", getTime(t, "2019-10-29T05:30:00+05:30")},
+		{"string array(set)", ddl.String{Len: ddl.MaxLength{}}, true, "", "1,Travel,3,Dance", []spanner.NullString{
+			spanner.NullString{StringVal: "1", Valid: true},
+			spanner.NullString{StringVal: "Travel", Valid: true},
+			spanner.NullString{StringVal: "3", Valid: true},
+			spanner.NullString{StringVal: "Dance", Valid: true}}},
+	}
+	tableName := "testtable"
+	for _, tc := range tc {
+		col := "a"
+		conv := internal.MakeConv()
+		cols := []string{col}
+		srcSchema := schema.Table{Name: tableName, ColNames: []string{col}, ColDefs: map[string]schema.Column{col: schema.Column{Type: schema.Type{Name: tc.srcTy}}}}
+		spSchema := ddl.CreateTable{
+			Name:     tableName,
+			ColNames: []string{col},
+			ColDefs:  map[string]ddl.ColumnDef{col: ddl.ColumnDef{Name: col, T: tc.ty, IsArray: tc.isArray}}}
+		conv.TimezoneOffset = "+05:30"
+		_, ac, av, err := ConvertData(conv, tableName, cols, srcSchema, tableName, cols, spSchema, []string{tc.in})
+		assert.Equal(t, cols, ac)
+		assert.Equal(t, []interface{}{tc.e}, av)
+		assert.Nil(t, err)
+	}
+}
+
+func TestConvertSqlRow_MultiCol(t *testing.T) {
+	// Tests multi-column behavior of ProcessSqlData (including
+	// handling of null columns and synthetic keys). Also tests
+	// the combination of ProcessInfoSchema and ProcessSqlData
+	// i.e. ProcessSqlData uses the schemas built by
+	// ProcessInfoSchema.
+	ms := []mockSpec{
+		{
+			query: "SELECT table_schema, table_name FROM information_schema.tables where table_type = 'BASE TABLE'",
+			cols:  []string{"table_schema", "table_name"},
+			rows:  [][]driver.Value{{"public", "test"}},
+		}, {
+			query: "SELECT (.+) FROM information_schema.COLUMNS (.+)",
+			args:  []driver.Value{"public", "test"},
+			cols:  []string{"column_name", "data_type", "column_type", "is_nullable", "column_default", "character_maximum_length", "numeric_precision", "numeric_scale"},
+			rows: [][]driver.Value{
+				{"a", "text", "text", "NO", nil, nil, nil, nil},
+				{"b", "double", "double", "YES", nil, nil, 53, nil},
+				{"c", "bigint", "bigint", "YES", nil, nil, 64, 0}},
+		},
+		{
+			query: "SELECT (.+) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS (.+)",
+			args:  []driver.Value{"public", "test"},
+			cols:  []string{"column_name", "constraint_type"},
+			rows:  [][]driver.Value{},
+		},
+		{
+			query: "SELECT table_schema, table_name FROM information_schema.tables where table_type = 'BASE TABLE'",
+			cols:  []string{"table_schema", "table_name"},
+			rows:  [][]driver.Value{{"public", "test"}},
+		}, {
+			query: `SELECT a,b,c FROM public.test`, // query is a regexp!
+			cols:  []string{"a", "b", "c"},
+			rows: [][]driver.Value{
+				{"cat", 42.3, nil},
+				{"dog", nil, 22}},
+		},
+	}
+	db := mkMockDb(t, ms)
+	conv := internal.MakeConv()
+	err := ProcessInfoSchema(conv, db)
+	assert.Nil(t, err)
+	expectedSchema := map[string]ddl.CreateTable{
+		"test": ddl.CreateTable{
+			Name:     "test",
+			ColNames: []string{"a", "b", "c", "synth_id"},
+			ColDefs: map[string]ddl.ColumnDef{
+				"a":        ddl.ColumnDef{Name: "a", T: ddl.String{Len: ddl.MaxLength{}}, NotNull: true},
+				"b":        ddl.ColumnDef{Name: "b", T: ddl.Float64{}},
+				"c":        ddl.ColumnDef{Name: "c", T: ddl.Int64{}},
+				"synth_id": ddl.ColumnDef{Name: "synth_id", T: ddl.Int64{}},
+			},
+			Pks: []ddl.IndexKey{ddl.IndexKey{Col: "synth_id"}}},
+	}
+	assert.Equal(t, expectedSchema, stripSchemaComments(conv.SpSchema))
+	expectedIssues := map[string][]internal.SchemaIssue{}
+	assert.Equal(t, expectedIssues, conv.Issues["test"])
+	assert.Equal(t, int64(0), conv.Unexpecteds())
+	conv.SetDataMode()
+	var rows []spannerData
+	conv.SetDataSink(
+		func(table string, cols []string, vals []interface{}) {
+			rows = append(rows, spannerData{table: table, cols: cols, vals: vals})
+		})
+	ProcessSqlData(conv, db)
+	assert.Equal(t, []spannerData{
+		{table: "test", cols: []string{"a", "b", "synth_id"}, vals: []interface{}{"cat", float64(42.3), int64(0)}},
+		{table: "test", cols: []string{"a", "c", "synth_id"}, vals: []interface{}{"dog", int64(22), int64(-9223372036854775808)}}},
+		rows)
+	assert.Equal(t, int64(0), conv.Unexpecteds())
+}
+
+func TestSetRowStats(t *testing.T) {
+	ms := []mockSpec{
+		{
+			query: "SELECT table_schema, table_name FROM information_schema.tables where table_type = 'BASE TABLE'",
+			cols:  []string{"table_schema", "table_name"},
+			rows:  [][]driver.Value{{"public", "test1"}, {"public", "test2"}},
+		}, {
+			query: `SELECT COUNT[(][*][)] FROM public.test1`,
+			cols:  []string{"count"},
+			rows:  [][]driver.Value{{5}},
+		}, {
+			query: `SELECT COUNT[(][*][)] FROM public.test2`,
+			cols:  []string{"count"},
+			rows:  [][]driver.Value{{142}},
+		},
+	}
+	db := mkMockDb(t, ms)
+	conv := internal.MakeConv()
+	conv.SetDataMode()
+	SetRowStats(conv, db)
+	assert.Equal(t, int64(5), conv.Stats.Rows["test1"])
+	assert.Equal(t, int64(142), conv.Stats.Rows["test2"])
+	assert.Equal(t, int64(0), conv.Unexpecteds())
+}
+
+func mkMockDb(t *testing.T, ms []mockSpec) *sql.DB {
+	db, mock, err := sqlmock.New()
+	assert.Nil(t, err)
+	for _, m := range ms {
+		rows := sqlmock.NewRows(m.cols)
+		for _, r := range m.rows {
+			rows.AddRow(r...)
+		}
+		if len(m.args) > 0 {
+			mock.ExpectQuery(m.query).WithArgs(m.args...).WillReturnRows(rows)
+		} else {
+			mock.ExpectQuery(m.query).WillReturnRows(rows)
+		}
+
+	}
+	return db
+}

--- a/mysql/toddl.go
+++ b/mysql/toddl.go
@@ -132,7 +132,7 @@ func toSpannerType(conv *internal.Conv, id string, mods []int64) (ddl.ScalarType
 		}
 		return ddl.String{Len: ddl.MaxLength{}}, nil
 	case "text", "tinytext", "mediumtext", "longtext":
-		maxExpectedMods(0)
+		maxExpectedMods(1)
 		return ddl.String{Len: ddl.MaxLength{}}, nil
 	case "set", "enum":
 		maxExpectedMods(0)
@@ -144,7 +144,7 @@ func toSpannerType(conv *internal.Conv, id string, mods []int64) (ddl.ScalarType
 		maxExpectedMods(1)
 		return ddl.Bytes{Len: ddl.MaxLength{}}, nil
 	case "tinyblob", "mediumblob", "blob", "longblob":
-		maxExpectedMods(0)
+		maxExpectedMods(1)
 		return ddl.Bytes{Len: ddl.MaxLength{}}, nil
 	case "date":
 		maxExpectedMods(1)


### PR DESCRIPTION
We are using [GO-MySQL-Driver](https://github.com/go-sql-driver/mysql) to use [database/sql](https://golang.org/pkg/database/sql/) package